### PR TITLE
Minor cleanup

### DIFF
--- a/c_emulator/remote_bitbang.cpp
+++ b/c_emulator/remote_bitbang.cpp
@@ -56,12 +56,9 @@ remote_bitbang_t::remote_bitbang_t(uint16_t port, jtag_dtm_t *tap,
 {
 }
 
-std::unique_ptr<remote_bitbang_t> remote_bitbang_t::make(uint16_t port,
-                                                         jtag_dtm_t *tap)
+std::unique_ptr<remote_bitbang_t>
+remote_bitbang_t::make(uint16_t port, uint64_t required_rti_cycles)
 {
-  if (!tap)
-    throw std::invalid_argument("tap cannot be null");
-
   // Create socket
   int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
   if (socket_fd == -1) {
@@ -122,16 +119,23 @@ std::unique_ptr<remote_bitbang_t> remote_bitbang_t::make(uint16_t port,
          ntohs(addr.sin_port));
   fflush(stdout);
 
+  jtag_dtm_t *tap = new jtag_dtm_t(required_rti_cycles);
   return std::unique_ptr<remote_bitbang_t>(
       new remote_bitbang_t(port, tap, socket_fd));
 }
 
-remote_bitbang_t::~remote_bitbang_t()
+void remote_bitbang_t::close_sockets()
 {
   if (socket_fd != -1)
     close(socket_fd);
   if (client_fd != -1)
     close(client_fd);
+}
+
+remote_bitbang_t::~remote_bitbang_t()
+{
+  close_sockets();
+  delete tap;
 }
 
 void remote_bitbang_t::accept_connection()
@@ -266,15 +270,7 @@ void remote_bitbang_t::execute_commands()
 
 void remote_bitbang_t::close_port()
 {
-  if (client_fd != -1) {
-    close(client_fd);
-    client_fd = -1;
-  }
-
-  if (socket_fd != -1) {
-    close(socket_fd);
-    socket_fd = -1;
-  }
+  close_sockets();
 
   printf("Remote bitbang port closed.\n");
   fflush(stdout);

--- a/c_emulator/remote_bitbang.h
+++ b/c_emulator/remote_bitbang.h
@@ -37,7 +37,8 @@ class jtag_dtm_t;
 
 class remote_bitbang_t {
 public:
-  static std::unique_ptr<remote_bitbang_t> make(uint16_t port, jtag_dtm_t *tap);
+  static std::unique_ptr<remote_bitbang_t> make(uint16_t port,
+                                                uint64_t required_rti_cycles);
 
   ~remote_bitbang_t();
 
@@ -62,6 +63,8 @@ private:
 
   // Check for a client connecting, and accept if there is one.
   void accept_connection();
+
+  void close_sockets();
 
   // Execute any commands the client has for us.
   void execute_commands();

--- a/c_emulator/riscv_sim.cpp
+++ b/c_emulator/riscv_sim.cpp
@@ -35,7 +35,6 @@
 #include "riscv_callbacks_if.h"
 #include "riscv_callbacks_log.h"
 #include "riscv_callbacks_rvfi.h"
-#include "jtag_dtm.h"
 #include "remote_bitbang.h"
 
 bool do_show_times = false;
@@ -593,8 +592,7 @@ int inner_main(int argc, char **argv)
     config_enable_rvfi = true;
     rvfi = rvfi_handler(rvfi_dii_port);
   } else if (rbb_port != 0) {
-    jtag_dtm_t *jtag_dtm = new jtag_dtm_t(required_rti_cycles);
-    remote_bitbang = remote_bitbang_t::make(rbb_port, jtag_dtm);
+    remote_bitbang = remote_bitbang_t::make(rbb_port, required_rti_cycles);
   }
 
   if (do_show_times) {


### PR DESCRIPTION
. make jtag_dtm_t an internal detail of remote_bitbang_t.  This ensures that it gets deleted
  when remote_bitbang_t is deleted, preventing a memory leak.
. consolidate socket closing into a function called from the destructor and when needed.